### PR TITLE
Updated database to include all surveys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ ENV POSTGRES_USER postgres
 ADD create-users.sql /docker-entrypoint-initdb.d/
 RUN chmod 755 /docker-entrypoint-initdb.d/create-users.sql
 
-ADD tests-passing.sql /docker-entrypoint-initdb.d/
-RUN chmod 755 /docker-entrypoint-initdb.d/tests-passing.sql
+ADD post-survey-create.sql /docker-entrypoint-initdb.d/
+RUN chmod 755 /docker-entrypoint-initdb.d/post-survey-create.sql
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 build:
-	docker build . -t sdcplatform/dev-postgres:latest
+	docker build . -t sdcplatform/ras-rm-docker-postgres:latest
 
 run:
 	docker-compose up -d

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ras-rm-docker-postgres
-Repo for containing docker image definitions for Postgres containers needed by RAS/RM
+Docker image definitions for Postgres containers needed by RAS/RM.  
 
 ## Building the docker image
 
@@ -32,6 +32,7 @@ There are a number of SQL dumps of the RAS/RM postgres database in varying stage
 - ci-seeded.sql: services.sql but with the addition of the collection instruments seeded
 - post-tests.sql: full database dump once the integration tests have completed the first time
 - tests-passing.sql: full database dump on successful completion of the integration tests (DEFAULT)
+- post-survey-create.sql : full database dump including correct survey data
 
 ### Empty database
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,6 @@ version: '3'
 services:
  dev-postgres:
   container_name: dev-postgres
-  image: sdcplatform/dev-postgres
+  image: sdcplatform/ras-rm-docker-postgres
   ports:
    - "${EX_POSTGRES_PORT}:5432"


### PR DESCRIPTION
Updated default docker image to include all proposed new survey data.    One thing to note is the database dump is starting to get large (~48M) but the easiest way is to just dump out a running database.  I noticed I have ~200k action.actionplanjob rows - are these necessary? What else can be dumped out?